### PR TITLE
Custom args

### DIFF
--- a/src/main/scala/com/twitter/ostrich/admin/RuntimeEnvironment.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/RuntimeEnvironment.scala
@@ -99,8 +99,9 @@ class RuntimeEnvironment(obj: AnyRef) {
    */
   def parseArgs(args: List[String]): Unit = {
     args match {
-      case "-D" :: arg :: value :: xs =>
-        parseSetting(arg, value)
+      case "-D" :: arg :: xs =>
+        val split = arg.split("=")
+        parseSetting(split(0), split(1))
         parseArgs(xs)
       case "-f" :: filename :: xs =>
         configFile = new File(filename)

--- a/src/test/scala/com/twitter/ostrich/admin/RuntimeEnvironmentSpec.scala
+++ b/src/test/scala/com/twitter/ostrich/admin/RuntimeEnvironmentSpec.scala
@@ -36,7 +36,7 @@ class RuntimeEnvironmentSpec extends Specification {
 
     "parse custom args" in {
       val runtime = new RuntimeEnvironment(classOf[Object])
-      runtime.parseArgs(List("-D", "foo", "bar"))
+      runtime.parseArgs(List("-D", "foo=bar"))
       runtime.arguments.get("foo") mustEqual Some("bar")
     }
   }


### PR DESCRIPTION
We needed to add custom arguments in order to pass in port numbers, so we added the "-D" argument, which is then accessible from RuntimeEnvironment.
