### PR TITLE
Convert path to an absolute path in order to find the parent directory

### DIFF
--- a/src/main/scala/com/twitter/ostrich/admin/RuntimeEnvironment.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/RuntimeEnvironment.scala
@@ -76,7 +76,9 @@ class RuntimeEnvironment(obj: AnyRef) {
   lazy val jarPath: Option[String] = {
     val paths = System.getProperty("java.class.path").split(System.getProperty("path.separator"))
     findCandidateJar(paths, jarName, jarVersion).flatMap { path =>
-      val parent = new File(path).getParentFile
+      val file = new File(path);
+      var parent = file.getParentFile
+      if (parent == null) parent = file.getAbsoluteFile.getParentFile
       if (parent == null) None else Some(parent.getCanonicalPath)
     }
   }


### PR DESCRIPTION
This is a fix for https://github.com/robey/kestrel/issues/45; it allows you to successfully launch kestrel like this:

```
java ... -jar kestrel-2.1.1.jar
```

whereas before you had to do this:

```
java ... -jar ./kestrel-2.1.1.jar
```

(when chdir'd in to the same directory as the jar.)

Minor issue but confusing when you run into it.
