### PR TITLE
adding the handy DeathRattleExceptionHandler

### DIFF
--- a/src/main/scala/com/twitter/ostrich/stats/DeathRattleExceptionHandler.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/DeathRattleExceptionHandler.scala
@@ -1,0 +1,36 @@
+package com.twitter.ostrich.stats
+
+/**
+ * When a thread throws an Exception that was not caught, a DeathRattleExceptionHandler will
+ * increment a counter signalling a thread has died and print out the name and stack trace of the
+ * thread.
+ *
+ * This makes it easy to build alerts on unexpected Thread deaths and fine grained used quickens
+ * debugging in production.
+ *
+ * You can also set a DeathRattleExceptionHandler as the default exception handler on all threads,
+ * allowing you to get information on Threads you do not have direct control over.
+ *
+ * Usage is straightforward:
+ *
+ * {{{
+ * val c = Stats.getCounter("my_runnable_thread_deaths")
+ * val exHandler = new DeathRattleExceptionHandler(c)
+ * val myThread = new Thread(myRunnable, "my_runnable")
+ * myThread.setExceptionHandler(exHandler)
+ * }}}
+ *
+ * Setting the global default exception handler should be done first, like so:
+ * {{{
+ * val c = Stats.getCounter("unhandled_thread_deaths")
+ * val ohNoIDidntKnowAboutThis = new DeathRattleExceptionHandler(c)
+ * Thread.setDefaultExceptionHandler(ohNoIDidntKnowAboutThis)
+ * }}}
+ */
+class DeathRattleExceptionHandler(deathRattle: Counter) extends Thread.UncaughtExceptionHandler {
+  def uncaughtException(t: Thread, e: Throwable) {
+    deathRattle.incr()
+    System.err.println("Uncaught exception on thread " + t)
+    e.printStackTrace()
+  }
+}

--- a/src/main/scala/com/twitter/ostrich/stats/DeathRattleExceptionHandler.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/DeathRattleExceptionHandler.scala
@@ -16,15 +16,15 @@ package com.twitter.ostrich.stats
  * {{{
  * val c = Stats.getCounter("my_runnable_thread_deaths")
  * val exHandler = new DeathRattleExceptionHandler(c)
- * val myThread = new Thread(myRunnable, "my_runnable")
- * myThread.setExceptionHandler(exHandler)
+ * val myThread = new Thread(myRunnable, "MyRunnable")
+ * myThread.setUncaughtExceptionHandler(exHandler)
  * }}}
  *
  * Setting the global default exception handler should be done first, like so:
  * {{{
  * val c = Stats.getCounter("unhandled_thread_deaths")
  * val ohNoIDidntKnowAboutThis = new DeathRattleExceptionHandler(c)
- * Thread.setDefaultExceptionHandler(ohNoIDidntKnowAboutThis)
+ * Thread.setDefaultUncaughtExceptionHandler(ohNoIDidntKnowAboutThis)
  * }}}
  */
 class DeathRattleExceptionHandler(deathRattle: Counter) extends Thread.UncaughtExceptionHandler {

--- a/src/main/scala/com/twitter/ostrich/stats/DeathRattleExceptionHandler.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/DeathRattleExceptionHandler.scala
@@ -20,7 +20,8 @@ package com.twitter.ostrich.stats
  * myThread.setUncaughtExceptionHandler(exHandler)
  * }}}
  *
- * Setting the global default exception handler should be done first, like so:
+ * Setting the global default exception handler is handled for you if you use RuntimeEnvironment config loading, but
+ * can also be done by yourself like so:
  * {{{
  * val c = Stats.getCounter("unhandled_thread_deaths")
  * val ohNoIDidntKnowAboutThis = new DeathRattleExceptionHandler(c)


### PR DESCRIPTION
An easy way of getting information for alerting and debugging on unhandled exceptions.