### PR TITLE
Named callback handling

### DIFF
--- a/src/main/scala/com/twitter/ostrich/admin/AdminHttpService.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/AdminHttpService.scala
@@ -257,7 +257,13 @@ class CommandRequestHandler(commandHandler: CommandHandler) extends CgiRequestHa
         val commandResponse = commandHandler(command, parameterMap, format)
 
         if (parameterMap.keySet.contains("callback") && (format == Format.Json)) {
-          "ostrichCallback(%s)".format(commandResponse)
+          val callbackName = parameterMap.get("callback") match {
+              case Some("true") => "ostrichCallback"
+              case Some("") => "ostrichCallback" // Just in case callback= shows up
+              case Some(x) => x
+              case None => "ostrichCallBack" // This shouldn't happen
+          }
+          "%s(%s)".format(callbackName,commandResponse)
         } else {
           commandResponse
         }

--- a/src/test/scala/com/twitter/ostrich/admin/AdminHttpServiceSpec.scala
+++ b/src/test/scala/com/twitter/ostrich/admin/AdminHttpServiceSpec.scala
@@ -306,6 +306,18 @@ object AdminHttpServiceSpec extends ConfiguredSpecification with DataTables {
         stats.endsWith(")") mustBe true
       }
 
+      "in json, with named callback" in {
+        val stats = get("/stats.json?callback=My.Awesome.Callback")
+        stats.startsWith("My.Awesome.Callback(") mustBe true
+        stats.endsWith(")") mustBe true
+      }
+
+      "in json, with empty callback" in {
+        val stats = get("/stats.json?callback=")
+        stats.startsWith("ostrichCallback(") mustBe true
+        stats.endsWith(")") mustBe true
+      }
+
       "in text" in {
         // make some statsy things happen
         Stats.clearAll()


### PR DESCRIPTION
Was trying to use some of ostrich's stats with a JSONP library and noticed that the callback feature didn't support specifying the name of the callback.  I've added that feature and included a compatibility feature that callback=true (or callback=) will show the same behavior as before.

Thanks!
