### PR TITLE
Format the string to send to Graphite in the US Locale

### DIFF
--- a/src/main/scala/com/twitter/ostrich/stats/GraphiteStatsLogger.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/GraphiteStatsLogger.scala
@@ -77,7 +77,7 @@ class GraphiteStatsLogger(val host: String, val port: Int, val period: Duration,
 
       try {
         cleanedKeysStatMap.foreach { case (key, value) => {
-          writer.write("%s.%s.%s %.2f %d\n".format(prefix, serviceName.getOrElse("unknown"), key, value.doubleValue,
+          writer.write("%s.%s.%s %.2f %d\n".formatLocal(java.util.Locale.US, prefix, serviceName.getOrElse("unknown"), key, value.doubleValue,
             epoch))
         }}
       } catch {

--- a/src/test/scala/com/twitter/ostrich/stats/GraphiteStatsLoggerSpec.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/GraphiteStatsLoggerSpec.scala
@@ -53,8 +53,8 @@ object GraphiteStatsLoggerSpec extends Specification with JMocker with ClassMock
       collection.incr("dogs", 3)
       statsLogger.write(socket)
       val lines = getLines().sorted
-      lines(0) must beMatching("server_pool.unknown.cats 1.00 [0-9]+")
-      lines(1) must beMatching("server_pool.unknown.dogs 3.00 [0-9]+")
+      lines(0) must beMatching("server_pool\\.unknown\\.cats 1\\.00 [0-9]+")
+      lines(1) must beMatching("server_pool\\.unknown\\.dogs 3\\.00 [0-9]+")
     }
 
     "log timings" in {
@@ -63,8 +63,8 @@ object GraphiteStatsLoggerSpec extends Specification with JMocker with ClassMock
         collection.time("zzz") { time advance 20.milliseconds }
         statsLogger.write(socket)
         val lines = getLines().sorted
-        lines(0) must beMatching("server_pool.unknown.zzz_msec_average 15.00 [0-9]+")
-        lines(9) must beMatching("server_pool.unknown.zzz_msec_p99 19.00 [0-9]+")
+        lines(0) must beMatching("server_pool\\.unknown\\.zzz_msec_average 15\\.00 [0-9]+")
+        lines(9) must beMatching("server_pool\\.unknown\\.zzz_msec_p99 19\\.00 [0-9]+")
       }
     }
 
@@ -73,8 +73,8 @@ object GraphiteStatsLoggerSpec extends Specification with JMocker with ClassMock
       collection.setGauge("cow", 123456789.0)
       statsLogger.write(socket)
       val lines = getLines().sorted
-      lines(0) must beMatching("server_pool.unknown.cow 123456789.00 [0-9]+")
-      lines(1) must beMatching("server_pool.unknown.horse 3.50 [0-9]+")
+      lines(0) must beMatching("server_pool\\.unknown\\.cow 123456789\\.00 [0-9]+")
+      lines(1) must beMatching("server_pool\\.unknown\\.horse 3\\.50 [0-9]+")
     }
   }
 }


### PR DESCRIPTION
Since my development system is set in another locale, the code would write comma as the decimal separator, which Graphite couldn't accept. The tests didn't catch that because they would only check for any character instead of an escaped period.
