### PR TITLE
Start pruning removed stats from SwiftypeTimeSeriesCollector

### DIFF
--- a/src/main/scala/com/twitter/ostrich/admin/TimeSeriesCollector.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/TimeSeriesCollector.scala
@@ -74,7 +74,29 @@ class TimeSeriesCollector(collection: StatsCollection) extends Service {
         }
         hourlyTimings.getOrElseUpdate("metric:" + k, new TimeSeries[List[Long]](60, EMPTY_TIMINGS)).add(data)
       }
+
+      pruneStats(stats)
+
       lastCollection = Time.now
+    }
+
+    def pruneStats(stats: StatsSummary) {
+      hourly.retain { case (k, v) =>
+        if (k.startsWith("gauge:")) {
+          stats.gauges.contains(k.stripPrefix("gauge:"))
+        } else if (k.startsWith("counter:")) {
+          stats.counters.contains(k.stripPrefix("counter:"))
+        } else {
+          true
+        }
+      }
+      hourlyTimings.retain { case (k, v) =>
+        if (k.startsWith("metric:")) {
+          stats.metrics.contains(k.stripPrefix("metric:"))
+        } else {
+          true
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Once a stat was added to hourly or hourlyTimings it was never removed.
Now once a Gauge or Counter does not exist in StatsSummary the stat
is pruned.