### PR TITLE
Fix sbt error when configuring project settings

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -74,7 +74,6 @@ object Ostrich extends Build {
 
   lazy val ostrich = Project(
     id = "ostrich",
-    base = file("."),
-    settings = Project.defaultSettings ++ sharedSettings
-  )
+    base = file(".")
+  ).settings(sharedSettings)
 }


### PR DESCRIPTION
**Problem**
Sbt was failing on the following error:
`java.lang.IllegalArgumentException: Cannot add dependency 'org.scala-lang#scala-compiler;2.11.8' to configuration 'ensime-internal' of module com.twitter#ostrich_2.11;9.18.0-SNAPSHOT because this configuration doesn't exist!`

SBT version: 0.13.11 and Scala version: 2.11.7

**Solution**
Use Project#settings because some sbt plugins may try to modify settings at Project construction.
See: http://stackoverflow.com/questions/35067187/sbt-idiomatic-way-to-add-settings/35545637#35545637


**Why**
[Finagle's dependency setup script](https://github.com/twitter/finagle/blob/develop/bin/travisci) was failing because it depends on this repo.