### PR TITLE
Use https instead of http in urls

### DIFF
--- a/CONFIG.ini
+++ b/CONFIG.ini
@@ -1,4 +1,4 @@
-; See http://go/CONFIG.ini
+; See https://go/CONFIG.ini
 
 ; owned by Core System Libraries
 [jira]

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ostrich
 
 [![Build status](https://travis-ci.org/twitter/ostrich.svg?branch=develop)](https://travis-ci.org/twitter/ostrich)
-[![Codecov branch](https://img.shields.io/codecov/c/github/twitter/ostrich/develop.svg)](http://codecov.io/github/twitter/ostrich?branch=develop)
+[![Codecov branch](https://img.shields.io/codecov/c/github/twitter/ostrich/develop.svg)](https://codecov.io/github/twitter/ostrich?branch=develop)
 [![Project status](https://img.shields.io/badge/status-deprecated-orange.svg)](#status)
 
 Ostrich is a library for scala servers that makes it easy to:
@@ -264,12 +264,12 @@ Commands over the admin interface take the form of an HTTP "get" request:
 
 which can be performed using 'curl' or 'wget':
 
-    $ curl http://localhost:PPPP/shutdown
+    $ curl https://localhost:PPPP/shutdown
 
 The result body may be json or plain-text, depending on <type>. The default is
 json, but you can ask for text like so:
 
-    $ curl http://localhost:PPPP/stats.txt
+    $ curl https://localhost:PPPP/stats.txt
 
 For simple commands like `shutdown`, the response body may simply be the JSON
 encoding of the string "ok". For others like `stats`, it may be a nested
@@ -331,7 +331,7 @@ data on collected stats.
 
 The url
 
-    http://localhost:PPPP/graph/
+    https://localhost:PPPP/graph/
 
 (where PPPP is your admin `httpPort`) will give a list of currently-collected
 stats, and links to the current hourly graph for each stat. The graphs are
@@ -348,7 +348,7 @@ Example use:
     curl -s 'localhost:9990/pprof/heap?pause=10' >| /tmp/prof
 
 This will result in a file that you can be read with
-[pprof](http://goog-perftools.sourceforge.net/doc/cpu_profiler.html)
+[pprof](https://goog-perftools.sourceforge.net/doc/cpu_profiler.html)
 
 
 ## Credits

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -56,7 +56,7 @@ object Ostrich extends Build {
       <licenses>
         <license>
           <name>Apache 2</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
           <distribution>repo</distribution>
           <comments>A business-friendly OSS license</comments>
         </license>

--- a/sbt
+++ b/sbt
@@ -4,7 +4,7 @@ sbtver=0.13.9
 sbtjar=sbt-launch.jar
 sbtsha128=1de48c2c412fffc4336e4d7dee224927a96d5abc
 
-sbtrepo=http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch
+sbtrepo=https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch
 
 if [ ! -f $sbtjar ]; then
   echo "downloading $PWD/$sbtjar" 1>&2

--- a/src/main/resources/graph.html
+++ b/src/main/resources/graph.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "https://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">

--- a/src/main/resources/report_request_handler.html
+++ b/src/main/resources/report_request_handler.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Stats Report</title>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.0/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.0/jquery.min.js" type="text/javascript"></script>
     <style type="text/css">
     body {
       font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
@@ -65,7 +65,7 @@
     </script>
     <div id="footer">
       generated at <span id="gendate"></span><br />
-      brought to you by <a href="http://github.com/stevej/ostrich/">Ostrich</a>
+      brought to you by <a href="https://github.com/stevej/ostrich/">Ostrich</a>
     </div>
   </body>
 </html>

--- a/src/main/resources/static/jquery.js
+++ b/src/main/resources/static/jquery.js
@@ -1,10 +1,10 @@
 /*!
  * jQuery JavaScript Library v1.3.2
- * http://jquery.com/
+ * https://jquery.com/
  *
  * Copyright (c) 2009 John Resig
  * Dual licensed under the MIT and GPL licenses.
- * http://docs.jquery.com/License
+ * https://docs.jquery.com/License
  *
  * Date: 2009-02-19 17:34:21 -0500 (Thu, 19 Feb 2009)
  * Revision: 6246
@@ -646,7 +646,7 @@ jQuery.extend({
 	globalEval: function( data ) {
 		if ( data && /\S/.test(data) ) {
 			// Inspired by code by Andrea Giammarchi
-			// http://webreflection.blogspot.com/2007/08/global-scope-evaluation-and-dom.html
+			// https://webreflection.blogspot.com/2007/08/global-scope-evaluation-and-dom.html
 			var head = document.getElementsByTagName("head")[0] || document.documentElement,
 				script = document.createElement("script");
 
@@ -822,7 +822,7 @@ jQuery.extend({
 			ret = elem.currentStyle[ name ] || elem.currentStyle[ camelCase ];
 
 			// From the awesome hack by Dean Edwards
-			// http://erik.eae.net/archives/2007/07/27/18.54.15/#comment-102291
+			// https://erik.eae.net/archives/2007/07/27/18.54.15/#comment-102291
 
 			// If we're not dealing with a regular pixel number
 			// but a number that has a weird ending, we need to convert it to pixels
@@ -1003,7 +1003,7 @@ jQuery.extend({
 					return elem.getAttributeNode( name ).nodeValue;
 
 				// elem.tabIndex doesn't always return the correct value when it hasn't been explicitly set
-				// http://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
+				// https://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
 				if ( name == "tabIndex" ) {
 					var attributeNode = elem.getAttributeNode( "tabIndex" );
 					return attributeNode && attributeNode.specified
@@ -1414,7 +1414,7 @@ jQuery.fn.extend({
  * Sizzle CSS Selector Engine - v0.9.3
  *  Copyright 2009, The Dojo Foundation
  *  Released under the MIT, BSD, and GPL Licenses.
- *  More information: http://sizzlejs.com/
+ *  More information: https://sizzlejs.com/
  */
 (function(){
 
@@ -2825,7 +2825,7 @@ function returnTrue(){
 }
 
 // jQuery.Event is based on DOM3 Events as specified by the ECMAScript Language Binding
-// http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
+// https://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
 jQuery.Event.prototype = {
 	preventDefault: function() {
 		this.isDefaultPrevented = returnTrue;
@@ -3074,7 +3074,7 @@ function bindReady(){
 
 			try {
 				// If IE is used, use the trick by Diego Perini
-				// http://javascript.nwbox.com/IEContentLoaded/
+				// https://javascript.nwbox.com/IEContentLoaded/
 				document.documentElement.doScroll("left");
 			} catch( error ) {
 				setTimeout( arguments.callee, 0 );

--- a/src/main/scala/com/twitter/ostrich/admin/AdminHttpService.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/AdminHttpService.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -490,7 +490,7 @@ class AdminHttpService private[ostrich](
       System.setProperty(property, value.toString)
   }
   // See meaning of those properties here:
-  // http://www.docjar.com/html/api/sun/net/httpserver/ServerConfig.java.html
+  // https://www.docjar.com/html/api/sun/net/httpserver/ServerConfig.java.html
   setPropertyIfNull("sun.net.httpserver.clockTick", 1000)
   setPropertyIfNull("sun.net.httpserver.timerMillis", 1000)
   setPropertyIfNull("sun.net.httpserver.maxReqTime", 25)

--- a/src/main/scala/com/twitter/ostrich/admin/BackgroundProcess.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/BackgroundProcess.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/admin/CommandHandler.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/CommandHandler.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/admin/Heapster.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/Heapster.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/admin/RuntimeEnvironment.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/RuntimeEnvironment.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,7 +42,7 @@ object RuntimeEnvironment {
  * relative to the executable jar.
  *
  * An example of how to generate a `build.properties` file is included in
- * sbt standard-project: <http://github.com/twitter/standard-project>
+ * sbt standard-project: <https://github.com/twitter/standard-project>
  *
  * You have to pass in an object from your package in order to identify the
  * location of the `build.properties` file.  The ClassLoader for the given object

--- a/src/main/scala/com/twitter/ostrich/admin/Service.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/Service.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/admin/ServiceTracker.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/ServiceTracker.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/admin/TimeSeriesCollector.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/TimeSeriesCollector.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/admin/config/AdminServiceConfig.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/config/AdminServiceConfig.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/admin/config/ServerConfig.scala
+++ b/src/main/scala/com/twitter/ostrich/admin/config/ServerConfig.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/Counter.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/Counter.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/Distribution.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/Distribution.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/GraphiteStatsLogger.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/GraphiteStatsLogger.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/Histogram.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/Histogram.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/JsonStatsLogger.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/JsonStatsLogger.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/Metric.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/Metric.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/Stats.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/Stats.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/StatsCollection.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/StatsCollection.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/StatsListener.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/StatsListener.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/StatsProvider.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/StatsProvider.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/W3CStats.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/W3CStats.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stats/W3CStatsLogger.scala
+++ b/src/main/scala/com/twitter/ostrich/stats/W3CStatsLogger.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/com/twitter/ostrich/stress/W3CStresser.scala
+++ b/src/main/scala/com/twitter/ostrich/stress/W3CStresser.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/scripts/json_stats_fetcher.rb
+++ b/src/scripts/json_stats_fetcher.rb
@@ -3,7 +3,7 @@
 # json_stats_fetcher.rb - Publish Ostrich stats to Ganglia.
 #
 # The latest version is always available at:
-# http://github.com/twitter/ostrich/blob/master/src/scripts/json_stats_fetcher.rb
+# https://github.com/twitter/ostrich/blob/master/src/scripts/json_stats_fetcher.rb
 #
 
 require 'rubygems'
@@ -103,7 +103,7 @@ begin
         # Ostrich 4.2 uses namespace for similar functionality
         args += "&reset=1&namespace=ganglia"
       end
-      url = "http://#{hostname}:#{port}/stats.json?#{args}"
+      url = "https://#{hostname}:#{port}/stats.json?#{args}"
       open(url).read
     else
       socket = TCPSocket.new(hostname, port)

--- a/src/test/scala/com/twitter/ostrich/admin/AdminHttpServiceTest.scala
+++ b/src/test/scala/com/twitter/ostrich/admin/AdminHttpServiceTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,7 +42,7 @@ class AdminHttpServiceTest extends FunSuite with BeforeAndAfter
 
   def get(path: String): String = {
     val port = service.address.getPort
-    val url = new URL(f"http://localhost:$port%d$path%s")
+    val url = new URL(f"https://localhost:$port%d$path%s")
     Source.fromURL(url).getLines().mkString("\n")
   }
 
@@ -53,7 +53,7 @@ class AdminHttpServiceTest extends FunSuite with BeforeAndAfter
 
   def getHeaders(path: String): Map[String, List[String]] = {
     val port = service.address.getPort
-    val url = new URL(f"http://localhost:$port%d$path%s")
+    val url = new URL(f"https://localhost:$port%d$path%s")
     url.openConnection().getHeaderFields.asScala.toMap.mapValues { _.asScala.toList }
   }
 

--- a/src/test/scala/com/twitter/ostrich/admin/RuntimeEnvironmentTest.scala
+++ b/src/test/scala/com/twitter/ostrich/admin/RuntimeEnvironmentTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/admin/ServiceTrackerTest.scala
+++ b/src/test/scala/com/twitter/ostrich/admin/ServiceTrackerTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/admin/TimeSeriesCollectorTest.scala
+++ b/src/test/scala/com/twitter/ostrich/admin/TimeSeriesCollectorTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,7 +42,7 @@ class TimeSeriesCollectorTest extends FunSuite with BeforeAndAfter {
   }
 
   def getJson[T](port: Int, path: String, valueType: Class[T]): T = {
-    val url = new URL("http://localhost:%d%s".format(port, path))
+    val url = new URL("https://localhost:%d%s".format(port, path))
     val objectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
     objectMapper.readValue(Source.fromURL(url).getLines.mkString("\n"), valueType)
   }

--- a/src/test/scala/com/twitter/ostrich/admin/config/AdminServiceConfigTest.scala
+++ b/src/test/scala/com/twitter/ostrich/admin/config/AdminServiceConfigTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -112,7 +112,7 @@ class AdminServiceConfigTest extends FunSuite with BeforeAndAfter with MockitoSu
 
       val port = service.address.getPort
       val path = "/stats.json?period=60&filtered=1"
-      val url = new URL("http://localhost:%s%s".format(port, path))
+      val url = new URL("https://localhost:%s%s".format(port, path))
       val data = Source.fromURL(url).getLines().mkString("\n")
       val mapper = new ObjectMapper().registerModule(DefaultScalaModule)
       val json = mapper.readValue(data, classOf[Map[String, Map[String, AnyRef]]])

--- a/src/test/scala/com/twitter/ostrich/stats/DistributionTest.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/DistributionTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/stats/GraphiteStatsLoggerTest.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/GraphiteStatsLoggerTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/stats/HistogramTest.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/HistogramTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/stats/JsonStatsLoggerTest.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/JsonStatsLoggerTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/stats/MetricTest.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/MetricTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/stats/StatsCollectionTest.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/StatsCollectionTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/stats/StatsListenerTest.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/StatsListenerTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/stats/StatsTest.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/StatsTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/stats/W3CStatsLoggerTest.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/W3CStatsLoggerTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/com/twitter/ostrich/stats/W3CStatsTest.scala
+++ b/src/test/scala/com/twitter/ostrich/stats/W3CStatsTest.scala
@@ -5,7 +5,7 @@
  * not use this file except in compliance with the License. You may obtain
  * a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.